### PR TITLE
tools/makemake: Use bash instead of /bin/sh

### DIFF
--- a/tools/makemake
+++ b/tools/makemake
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 t=makemake.targets
 T=makemake.TARGETS


### PR DESCRIPTION
That might probably work on systems that point /bin/sh to bash, but on real POSIX systems (e.g. Debian, where /bin/sh is dash), it does not.  Thus really use bash.

Other scripts that use /bin/sh might also be broken, but I did not check those.
