### PR TITLE
Fixes for the rewritefrom functionality

### DIFF
--- a/bin/ezmlm-cgi.c
+++ b/bin/ezmlm-cgi.c
@@ -1437,7 +1437,7 @@ void show_part(struct msginfo *infop,int flagshowheaders,int flagstartseen)
 	    }
 	    if (flagobscure && i == HDR_FROM - 1) {
 	      oputs(" ");
-	      author_name(&decline,line.s,line.len);
+	      author_name(&decline,line.s,line.len,0);
 	      html_put(decline.s,decline.len);
 	    } else {
 	      decodeHDR(hdr[i].s,hdr[i].len,&decline);

--- a/bin/ezmlm-idx.c
+++ b/bin/ezmlm-idx.c
@@ -245,7 +245,7 @@ int main(int argc,char **argv)
       mkauthhash(lines.s,lines.len,hash);
       stralloc_catb(&line,hash,HASHLEN);
 
-      author_name(&author,lines.s,lines.len);
+      author_name(&author,lines.s,lines.len,0);
 
       (void) unfoldHDR(author.s,author.len,&lines,charset.s,&prefix,0);
 

--- a/bin/ezmlm-send.c
+++ b/bin/ezmlm-send.c
@@ -298,7 +298,7 @@ int idx_copy_insertsubject(void)
   stralloc_catb(&qline,hash,HASHLEN);
   stralloc_cats(&qline," ");
 
-  author_name(&from,lines.s,lines.len);
+  author_name(&from,lines.s,lines.len,0);
 
   (void) unfoldHDR(from.s,from.len,&lines,charset.s,&dcprefix,0);
   stralloc_cat(&qline,&lines);
@@ -335,14 +335,14 @@ static void rewrite_from()
 
   if (flagrewritefrom) {
     concatHDR(from.s,from.len,&lines);
-    author_name(&author,lines.s,lines.len);
+    author_name(&author,lines.s,lines.len,1);
     stralloc_0(&author);
     stralloc_copy(&dummy,&outlocal);
     stralloc_0(&dummy);
 
-    stralloc_copyb(&line,"From: \"",7);
+    stralloc_copyb(&line,"From: ",6);
     stralloc_cats(&line,MSG2(AUTHOR_VIA_LIST,author.s,dummy.s));
-    stralloc_catb(&line,"\" <",3);
+    stralloc_catb(&line," <",2);
     stralloc_catb(&line,outlocal.s,outlocal.len);
     stralloc_catb(&line,"@",1);
     stralloc_catb(&line,outhost.s,outhost.len);

--- a/bin/ezmlm-send.c
+++ b/bin/ezmlm-send.c
@@ -354,7 +354,7 @@ static void rewrite_from()
     if (flagreplytolist) {
       if (cc.s) {
         --cc.len;	/* remove '\n' */
-        stralloc_catb(&cc,",\n",2);
+        stralloc_catb(&cc,",\n ",3);
       }
       stralloc_catb(&cc,from.s,from.len);
     } else if (!flaghavereplyto) {

--- a/bin/ezmlm-send.c
+++ b/bin/ezmlm-send.c
@@ -81,6 +81,7 @@ static stralloc lines = {0};
 static stralloc subject = {0};
 static stralloc from = {0};
 static stralloc received = {0};
+static stralloc cc = {0};
 static stralloc prefix = {0};
 static stralloc content = {0};
 stralloc boundary = {0};
@@ -111,6 +112,7 @@ static int flagfoundokpart;		/* Found something to pass on. If multipart */
 					/* we set to 0 and then set to 1 for any */
 					/* acceptable mime part. If 0 -> reject */
 static int flagsawreceived;
+static int flaghavereplyto;
 static int flagprefixed;
 static unsigned int serial = 0;
 static int flagarchived;
@@ -318,6 +320,8 @@ static void rewrite_from()
   unsigned int at;
   int r;
 
+  stralloc_copyb(&line,"",0);
+
   /* If not unconditionally rewriting headers, turn it on for this
    * message if DMARC would prevent us from sending as-is. */
   if (!flagrewritefrom) {
@@ -347,9 +351,27 @@ static void rewrite_from()
     stralloc_catb(&line,"@",1);
     stralloc_catb(&line,outhost.s,outhost.len);
     stralloc_catb(&line,">\n",2);
-    stralloc_cats(&line,flagreplytolist ? "Cc:" : "Reply-To:");
+    if (flagreplytolist) {
+      if (cc.s) {
+        --cc.len;	/* remove '\n' */
+        stralloc_catb(&cc,",\n",2);
+      }
+      stralloc_catb(&cc,from.s,from.len);
+    } else if (!flaghavereplyto) {
+      stralloc_catb(&line,"Reply-To:",9);
+      stralloc_catb(&line,from.s,from.len);
+    }
+  } else {
+    stralloc_copyb(&line,"From:",5);
     stralloc_catb(&line,from.s,from.len);
   }
+
+  if (cc.s) {
+    stralloc_catb(&line,"Cc:",3);
+    stralloc_catb(&line,cc.s,cc.len);
+  }
+
+  stralloc_catb(&line,"\n",1);
 }
 
 int main(int argc,char **argv)
@@ -513,12 +535,14 @@ int main(int argc,char **argv)
   flagbadpart = 0;
   flagseenext = 0;
   flagsawreceived = 0;
+  flaghavereplyto = 0;
   flagarchiveonly = 0;
   for (;;) {
     if (gethdrln(subfdin,&line,&match,'\n') == -1)
       strerr_die2sys(111,FATAL,MSG(ERR_READ_INPUT));
     if (flaginheader && match) {
       if (line.len == 1) {		/* end of header */
+        rewrite_from();
 	flaginheader = 0;
         if (flagindexed)		/* std entry */
           r = idx_copy_insertsubject();	/* all indexed lists */
@@ -578,7 +602,7 @@ int main(int argc,char **argv)
 	       flagfoundokpart = 0;
                constmap_init(&mimeremovemap,mimeremove.s,mimeremove.len,0);
                flagbadpart = 1;		/* skip before first boundary */
-               qa_puts("\n");		/* to make up for the lost '\n' */
+               qa_put(line.s,line.len);	/* but we still need the current line */
             }
           }
         }
@@ -624,9 +648,14 @@ int main(int argc,char **argv)
           else if (case_startb(cp,cpafter-cp,"Quoted-Printable")) encin = 'Q';
         } else if (flaglistid && case_startb(line.s,line.len,"list-id:"))
 	  flagbadfield = 1;		/* suppress if we added our own */
-	else if (case_startb(line.s,line.len,"From:")) {
+        else if (!flagbadfield && case_startb(line.s,line.len,"Reply-To:"))
+          flaghavereplyto = 1;
+        else if (case_startb(line.s,line.len,"Cc:")) {
+          stralloc_copyb(&cc,line.s+3,line.len-3);
+          flagbadfield = 1;		/* written/adjusted by rewrite_from() */
+        } else if (case_startb(line.s,line.len,"From:")) {
 	  stralloc_copyb(&from,line.s+5,line.len-5);
-	  rewrite_from();
+          flagbadfield = 1;		/* written/adjusted by rewrite_from() */
         } else if (line.len == mydtline.len)
 	  if (!byte_diff(line.s,line.len,mydtline.s))
             strerr_die2x(100,FATAL,MSG(ERR_LOOPING));

--- a/bin/ezmlm-test.1
+++ b/bin/ezmlm-test.1
@@ -22,8 +22,7 @@ ezmlm-test \- test ezmlm programs
 .B ezmlm-test
 is run from the ezmlm build directory. It will test most of the
 functions of most of the programs in ezmlm-idx. The program prints
-status and error messages to stdout. It requires that qmail runs on the
-host and that mail delivery to a local user functions. The invoking user
+status and error messages to stdout. The invoking user
 should have read and execute permission to the files in the build
 directory, and write permission in the current directory.
 
@@ -32,10 +31,9 @@ the default connection information.
 
 .B ezmlm-test
 creates a test list in the directory ``__TSTDIR'' (in the current
-directory). This directory and ``dot.qmail-__tstlist*'' will be
-overwritten/removed by the program. In addition, the file
-``__TSTDIR_err'' is created. In cases of error, it often contains the
-error message from the failing program.
+directory). This directory will be overwritten/removed by the program.
+In addition, the file ``__TSTDIR_err'' is created. In cases of error,
+it often contains the error message from the failing program.
 
 .B ezmlm-test
 should complete without error.

--- a/lib/author.c
+++ b/lib/author.c
@@ -3,14 +3,16 @@
 
 void author_name(stralloc *out,const char *s,unsigned int l)
 /* s is a string that contains a from: line argument\n. We parse */
-/* s as follows: If there is an unquoted '<' we eliminate everything after */
-/* it else if there is a unquoted ';' we eliminate everything after it.    */
-/* Then, we eliminate LWSP and '"' from the beginning and end. Note that   */
-/* this is not strict rfc822, but all we need is a display handle that     */
-/* doesn't show the address. If in the remaining text there is a '@' we put*/
-/* in a '.' instead. Also, there are some non-rfc822 from lines out there  */
-/* and we still want to maximize the chance of getting a handle, even if it*/
-/* costs a little extra work.*/
+/* s as follows: If there is a quoted string use its content as the name.  */
+/* Else if there is an unquoted '<', use the text before it as the name.   */
+/* Else if there is comment text in parens use that. Failing all of the    */
+/* previous conditions, use the entire line. Then we eliminate LWSP and any*/
+/* bracketing '<' and '>' from the beginning and end. Note that this is not*/
+/* strict rfc822, but all we need is a display handle that doesn't show the*/
+/* address. If in the remaining text there is a '@' we put in a '.'        */
+/* instead. Also, there are some non-rfc822 from lines out there and we    */
+/* still want to maximize the chance of getting a handle, even if it costs */
+/* a little extra work.*/
 {
   int squote = 0;
   int dquote = 0;
@@ -97,14 +99,11 @@ void author_name(stralloc *out,const char *s,unsigned int l)
 
 void author_addr(stralloc *out,const char *s,unsigned int l)
 /* s is a string that contains a from: line argument\n. We parse */
-/* s as follows: If there is an unquoted '<' we eliminate everything after */
-/* it else if there is a unquoted ';' we eliminate everything after it.    */
-/* Then, we eliminate LWSP and '"' from the beginning and end. Note that   */
-/* this is not strict rfc822, but all we need is a display handle that     */
-/* doesn't show the address. If in the remaining text there is a '@' we put*/
-/* in a '.' instead. Also, there are some non-rfc822 from lines out there  */
-/* and we still want to maximize the chance of getting a handle, even if it*/
-/* costs a little extra work.*/
+/* s as follows: Ignore ';' and everything after it. If there are unquoted */
+/* and uncommented '<' and '>' characters use the text they bracket as the */
+/* address. Else if there is an unquoted/uncommented '@', use the non-     */
+/* whitespace characters surrounding it. Otherwise we couldn't find an     */
+/* address and return an empty string.                                     */
 {
   int squote = 0;
   int dquote = 0;

--- a/lib/mime.h
+++ b/lib/mime.h
@@ -12,7 +12,7 @@ extern void concatHDR(const char *,unsigned int,stralloc *);
 extern int unfoldHDR(char *,unsigned int,stralloc *,const char *, const stralloc *,int);
 
 extern void author_addr(stralloc *out,const char *,unsigned int);
-extern void author_name(stralloc *out,const char *,unsigned int);
+extern void author_name(stralloc *out,const char *,unsigned int,int);
 
 /* Characters */
 #define ESC 0x1B

--- a/tests/02-functions
+++ b/tests/02-functions
@@ -22,6 +22,16 @@ fatal() {
   exit 100;
 }
 
+unfoldhdrs() {
+  (cat "$QQHDR"; echo) |
+  sed -e '/^\([^ \t]\|$\)/x'            -e '# new header; swap hold/pattern'   \
+      -e '/^$/d'                        -e '# ignore initial empty hold'       \
+      -e '/^[ \t]/{' -e H -e d -e }     -e '# append continuation to hold'     \
+      -e 's/[ \t]*\n[ \t]*/ /g'         -e '# unfold concatenated header'      \
+    >"${TMP}hdr"
+  mv -f "${TMP}hdr" "$QQHDR"
+}
+
 grephdr() {
   # Search for the header line, and produce an error if it didn't match.
   egrep "^$*$" "$QQHDR" >/dev/null 2>&1 || \
@@ -34,6 +44,17 @@ grephdr() {
   # Remove any found lines from the header file
   grep -iv "^$1" "$QQHDR" >"${TMP}hdr"
   mv -f "${TMP}hdr" "$QQHDR"
+}
+
+singlehdr() {
+  # Search for the header and ensure it appears exactly once.
+  count=$(grep -i -c "^$1" "$QQHDR")
+  if [ "$count" -ne 1 ]; then
+    [ "$count" -eq 0 ] && echo "Missing $1 line."
+    [ "$count" -gt 1 ] && echo "Multiple $1 lines:" && grep -i "^$1" "$QQHDR"
+    BUG="${BUG} headers"
+    prompt "..............: "
+  fi
 }
 
 grepbody() {

--- a/tests/550-ezmlm-send
+++ b/tests/550-ezmlm-send
@@ -1,9 +1,11 @@
   prompt "ezmlm-send:           "
 
   sendfrom() {
-    cat >"$TMP" <<EOF
-From: $1
-Reply-To: $1
+    echo "From: $1" >"$TMP"
+    if [ -n "$2" ]; then
+        echo "Reply-To: $2" >>"$TMP"
+    fi
+    cat >>"$TMP" <<EOF
 Subject: test post
 X-Test-Header: one
 Content-Length: zip
@@ -26,7 +28,6 @@ EOF
   grephdr Subject: '\[PFX\] test post'
   grephdr X-Test-Header: one
   grephdr Sender: "<${LIST}@${HOST}>"
-  grephdr Reply-To: test1@example.org
   grephdr_empty
 
   grepbody Local: "$LOCAL"
@@ -40,7 +41,7 @@ EOF
   grephdr Subject: 'test post'
 
   touch "$DIR"/replytolist
-  sendfrom test2@example.org
+  sendfrom test2@example.org test2@example.org
 
   grephdr_list 1
   grephdr Precedence: bulk

--- a/tests/551-ezmlm-send-rewritefrom
+++ b/tests/551-ezmlm-send-rewritefrom
@@ -138,6 +138,23 @@ grephdr Reply-To: "<${LIST}@${HOST}>"
 singlehdr Cc:
 grephdr Cc: 'cc16@example.org, test16@example.org'
 
+cat >"$TMP" <<EOF
+From:"My Test 17" <test17@example.org>
+To:${LIST}@${HOST}
+Cc:cc17@example.org
+Subject:carbon-copied test post no spaces in headers
+
+message goes here
+EOF
+${EZBIN}/ezmlm-send "$DIR" <"$TMP" >"$ERR" 2>&1 || \
+    fatal "failed to produce post"
+unfoldhdrs
+grephdr From: "\"My Test 17\" via ${LIST} <${LIST}@${HOST}>$"
+singlehdr Reply-To:
+grephdr Reply-To: "<${LIST}@${HOST}>"
+singlehdr Cc:
+grephdr 'Cc:cc17@example.org, "My Test 17" <test17@example.org>'
+
 rm -f "$DIR"/rewritefrom "$DIR"/replytolist
 
 echo OK

--- a/tests/551-ezmlm-send-rewritefrom
+++ b/tests/551-ezmlm-send-rewritefrom
@@ -3,37 +3,47 @@ prompt "ezmlm-send (from):    "
 touch "$DIR"/rewritefrom
 
 sendfrom '"My Name 1" <test1@example.org>'
-grephdr From: "\"My Name 1 via ${LIST}\" <${LIST}@${HOST}>$"
+grephdr From: "\"My Name 1\" via ${LIST} <${LIST}@${HOST}>$"
 grephdr Reply-To: '"My Name 1" <test1@example.org>'
 
 sendfrom '"My Name 2" test2@example.org'
-grephdr From: "\"My Name 2 via ${LIST}\" <${LIST}@${HOST}>$"
+grephdr From: "\"My Name 2\" via ${LIST} <${LIST}@${HOST}>$"
 grephdr Reply-To: '"My Name 2" test2@example.org'
 
 sendfrom 'My Name 3 <test3@example.org>'
-grephdr From: "\"My Name 3 via ${LIST}\" <${LIST}@${HOST}>$"
+grephdr From: "My Name 3 via ${LIST} <${LIST}@${HOST}>$"
 grephdr Reply-To: 'My Name 3 <test3@example.org>'
 
 sendfrom 'test4@example.org (My Name 4)'
-grephdr From: "\"My Name 4 via ${LIST}\" <${LIST}@${HOST}>$"
+grephdr From: "\"My Name 4\" via ${LIST} <${LIST}@${HOST}>$"
 grephdr Reply-To: 'test4@example.org \(My Name 4\)'
 
 sendfrom 'test5@example.org'
-grephdr From: "\"test5.example.org via ${LIST}\" <${LIST}@${HOST}>$"
+grephdr From: "\"test5@example.org\" via ${LIST} <${LIST}@${HOST}>$"
 grephdr Reply-To: 'test5@example.org'
 
 rm -f "$DIR"/rewritefrom
 
 sendfrom 'test6@yahoo.com'
-grephdr From: "\"test6.yahoo.com via ${LIST}\" <${LIST}@${HOST}>$"
+grephdr From: "\"test6@yahoo.com\" via ${LIST} <${LIST}@${HOST}>$"
 grephdr Reply-To: 'test6@yahoo.com'
 
 sendfrom '"My Name 7" <test7@yahoo.com>'
-grephdr From: "\"My Name 7 via ${LIST}\" <${LIST}@${HOST}>$"
+grephdr From: "\"My Name 7\" via ${LIST} <${LIST}@${HOST}>$"
 grephdr Reply-To: '"My Name 7" <test7@yahoo.com>'
 
 sendfrom 'My Name 8 <test8@yahoo.com>'
-grephdr From: "\"My Name 8 via ${LIST}\" <${LIST}@${HOST}>$"
+grephdr From: "My Name 8 via ${LIST} <${LIST}@${HOST}>$"
 grephdr Reply-To: 'My Name 8 <test8@yahoo.com>'
+
+touch "$DIR"/rewritefrom
+
+sendfrom '=?iso-8859-1?Q?My=20N=E4m=E9=209?= <test9@example.org>'
+grephdr From: "=\\?iso-8859-1\\?Q\\?My=20N=E4m=E9=209\\?= via ${LIST} <${LIST}@${HOST}>$"
+grephdr Reply-To: '=\?iso-8859-1\?Q\?My=20N=E4m=E9=209\?= <test9@example.org>'
+
+sendfrom '=?utf-8?B?77yt772ZIMORw6ZtIDEw?= <test10@example.org>'
+grephdr From: "=\\?utf-8\\?B\\?77yt772ZIMORw6ZtIDEw\\?= via ${LIST} <${LIST}@${HOST}>$"
+grephdr Reply-To: '=\?utf-8\?B\?77yt772ZIMORw6ZtIDEw\?= <test10@example.org>'
 
 echo OK

--- a/tests/551-ezmlm-send-rewritefrom
+++ b/tests/551-ezmlm-send-rewritefrom
@@ -4,46 +4,112 @@ touch "$DIR"/rewritefrom
 
 sendfrom '"My Name 1" <test1@example.org>'
 grephdr From: "\"My Name 1\" via ${LIST} <${LIST}@${HOST}>$"
+singlehdr Reply-To:
 grephdr Reply-To: '"My Name 1" <test1@example.org>'
 
 sendfrom '"My Name 2" test2@example.org'
 grephdr From: "\"My Name 2\" via ${LIST} <${LIST}@${HOST}>$"
+singlehdr Reply-To:
 grephdr Reply-To: '"My Name 2" test2@example.org'
 
 sendfrom 'My Name 3 <test3@example.org>'
 grephdr From: "My Name 3 via ${LIST} <${LIST}@${HOST}>$"
+singlehdr Reply-To:
 grephdr Reply-To: 'My Name 3 <test3@example.org>'
 
 sendfrom 'test4@example.org (My Name 4)'
 grephdr From: "\"My Name 4\" via ${LIST} <${LIST}@${HOST}>$"
+singlehdr Reply-To:
 grephdr Reply-To: 'test4@example.org \(My Name 4\)'
 
 sendfrom 'test5@example.org'
 grephdr From: "\"test5@example.org\" via ${LIST} <${LIST}@${HOST}>$"
+singlehdr Reply-To:
 grephdr Reply-To: 'test5@example.org'
 
 rm -f "$DIR"/rewritefrom
 
 sendfrom 'test6@yahoo.com'
 grephdr From: "\"test6@yahoo.com\" via ${LIST} <${LIST}@${HOST}>$"
+singlehdr Reply-To:
 grephdr Reply-To: 'test6@yahoo.com'
 
 sendfrom '"My Name 7" <test7@yahoo.com>'
 grephdr From: "\"My Name 7\" via ${LIST} <${LIST}@${HOST}>$"
+singlehdr Reply-To:
 grephdr Reply-To: '"My Name 7" <test7@yahoo.com>'
 
 sendfrom 'My Name 8 <test8@yahoo.com>'
 grephdr From: "My Name 8 via ${LIST} <${LIST}@${HOST}>$"
+singlehdr Reply-To:
 grephdr Reply-To: 'My Name 8 <test8@yahoo.com>'
 
 touch "$DIR"/rewritefrom
 
 sendfrom '=?iso-8859-1?Q?My=20N=E4m=E9=209?= <test9@example.org>'
 grephdr From: "=\\?iso-8859-1\\?Q\\?My=20N=E4m=E9=209\\?= via ${LIST} <${LIST}@${HOST}>$"
+singlehdr Reply-To:
 grephdr Reply-To: '=\?iso-8859-1\?Q\?My=20N=E4m=E9=209\?= <test9@example.org>'
 
 sendfrom '=?utf-8?B?77yt772ZIMORw6ZtIDEw?= <test10@example.org>'
 grephdr From: "=\\?utf-8\\?B\\?77yt772ZIMORw6ZtIDEw\\?= via ${LIST} <${LIST}@${HOST}>$"
+singlehdr Reply-To:
 grephdr Reply-To: '=\?utf-8\?B\?77yt772ZIMORw6ZtIDEw\?= <test10@example.org>'
+
+sendfrom 'My Name 11 <test11@example.org>' 'Reply To 11 <reply11@example.org>'
+grephdr From: "My Name 11 via ${LIST} <${LIST}@${HOST}>$"
+singlehdr Reply-To:
+grephdr Reply-To: 'Reply To 11 <reply11@example.org>'
+
+sendfrom test12@example.org test12@example.org
+grephdr From: "\"test12@example.org\" via ${LIST} <${LIST}@${HOST}>$"
+singlehdr Reply-To:
+grephdr Reply-To: 'test12@example.org'
+
+touch "$DIR"/replytolist
+
+sendfrom '"My Name 13" <test13@example.org>'
+grephdr From: "\"My Name 13\" via ${LIST} <${LIST}@${HOST}>$"
+singlehdr Reply-To:
+grephdr Reply-To: "<${LIST}@${HOST}>"
+singlehdr Cc:
+grephdr Cc: '"My Name 13" <test13@example.org>'
+
+cat >"$TMP" <<EOF
+From: test14@example.org
+To: ${LIST}@${HOST}
+Cc: cc14@example.org
+Subject: carbon-copied test post
+
+message goes here
+EOF
+${EZBIN}/ezmlm-send "$DIR" <"$TMP" >"$ERR" 2>&1 || \
+    fatal "failed to produce post"
+unfoldhdrs
+grephdr From: "\"test14@example.org\" via ${LIST} <${LIST}@${HOST}>$"
+singlehdr Reply-To:
+grephdr Reply-To: "<${LIST}@${HOST}>"
+singlehdr Cc:
+grephdr Cc: 'cc14@example.org, test14@example.org'
+
+cat >"$TMP" <<EOF
+From: My Test 15 <test15@example.org>
+To: ${LIST}@${HOST}
+Cc: "Carbon Copy 15" <cc15@example.org>,
+ <cc15-addtl@example.org>
+Subject: carbon-copied test post
+
+message goes here
+EOF
+${EZBIN}/ezmlm-send "$DIR" <"$TMP" >"$ERR" 2>&1 || \
+    fatal "failed to produce post"
+unfoldhdrs
+grephdr From: "My Test 15 via ${LIST} <${LIST}@${HOST}>$"
+singlehdr Reply-To:
+grephdr Reply-To: "<${LIST}@${HOST}>"
+singlehdr Cc:
+grephdr Cc: '"Carbon Copy 15" <cc15@example.org>, <cc15-addtl@example.org>, My Test 15 <test15@example.org>'
+
+rm -f "$DIR"/rewritefrom "$DIR"/replytolist
 
 echo OK

--- a/tests/551-ezmlm-send-rewritefrom
+++ b/tests/551-ezmlm-send-rewritefrom
@@ -110,6 +110,34 @@ grephdr Reply-To: "<${LIST}@${HOST}>"
 singlehdr Cc:
 grephdr Cc: '"Carbon Copy 15" <cc15@example.org>, <cc15-addtl@example.org>, My Test 15 <test15@example.org>'
 
+cat >"$TMP" <<EOF
+From: test16@example.org
+To: ${LIST}@${HOST}
+Cc: cc16@example.org
+Subject: multipart/alternative MIME message
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="0000000062ea6ef9772a44f3a30a"
+
+--0000000062ea6ef9772a44f3a30a
+Content-Type: text/plain; charset="US-ASCII"
+
+Hello, world!
+
+--0000000062ea6ef9772a44f3a30a
+Content-Type: text/html; charset="US-ASCII"
+
+Hello, world!<br/> 
+--0000000062ea6ef9772a44f3a30a--
+EOF
+${EZBIN}/ezmlm-send "$DIR" <"$TMP" >"$ERR" 2>&1 || \
+    fatal "failed to produce post"
+unfoldhdrs
+grephdr From: "\"test16@example.org\" via ${LIST} <${LIST}@${HOST}>$"
+singlehdr Reply-To:
+grephdr Reply-To: "<${LIST}@${HOST}>"
+singlehdr Cc:
+grephdr Cc: 'cc16@example.org, test16@example.org'
+
 rm -f "$DIR"/rewritefrom "$DIR"/replytolist
 
 echo OK


### PR DESCRIPTION
Closes #12

Gmail has been rejecting some of the messages sent to ezmlm-idx mailing lists I help run. Eventually I determined it was due to the outgoing messages having two different Cc headers: one from the original poster and then a second with the poster's address, the latter having been added by the rewritefrom logic (we use replytolist). I saw that issue #12 mentions the same problem happening with Reply-To headers.

We had not noticed the issue with encoded words that is perhaps the main complaint in issue #12.  (We tend to all be Americans with 7-bit ASCII names.)

In any case, the duplicated headers problem is causing us a lot of trouble. Essentially we lose messages whenever somebody tries to use reply-all to messages sent on our lists. So I've implemented a fix. And since it was in the same GitHub issue, I also took a swing at maintaining encoded words in the author name of the rewritten From header.